### PR TITLE
two small typos and a suggestion

### DIFF
--- a/postnotes-doc.tex
+++ b/postnotes-doc.tex
@@ -293,7 +293,7 @@ For more details and some examples, see \zcref{sec:notes-sections}.  Its
     \cs{printpostnotes}
   \end{syntax}
 \end{function}
-Prints the postnotes set since the last call of \cs{printpostnotes}, or
+Prints the \cs{postnote}s set since the last call of \cs{printpostnotes}, or
 since the beginning of the document.  For two basic usage illustrations, see
 \zcref{ex:sect:basic,ex:x:multi-print}.
 
@@ -1112,10 +1112,5 @@ upon release so, most likely, \texttt{texdoc postnotes/changelog} should
 provide easy local access to it.  An archive of historical versions of the
 package is also kept at \url{https://github.com/gusbrs/postnotes/releases}.
 
-
-\section{Implementation}
-
-For those who would like to see the implementation of this package,
-just type \texttt{texdoc postnotes-code} in the terminal to get the code documentation.
 
 \end{document}

--- a/postnotes-doc.tex
+++ b/postnotes-doc.tex
@@ -293,7 +293,7 @@ For more details and some examples, see \zcref{sec:notes-sections}.  Its
     \cs{printpostnotes}
   \end{syntax}
 \end{function}
-Prints the \cs{postnotes} set since the last call of \cs{printpostnotes}, or
+Prints the postnotes set since the last call of \cs{printpostnotes}, or
 since the beginning of the document.  For two basic usage illustrations, see
 \zcref{ex:sect:basic,ex:x:multi-print}.
 
@@ -632,7 +632,7 @@ among mostly numbered chapters, an ocasional unnumbered one?\footnote{The
   example here counts on the lucky circumstance of having only a single
   initial unnumbered section.  But, in general, if that's not the case,
   \cs{counterwithin*} is insufficient and the resetting of the
-  \texttt{postnote} counter at unnumbered sections most be handled somehow
+  \texttt{postnote} counter at unnumbered sections must be handled somehow
   else.}  \cs{pnthechapternextnote} wouldn't possibly work in this case.
 Since immediately successive calls to \cs{postnotesection} override the
 previous ones, it is straightforward to just manually adjust the exception:
@@ -822,7 +822,7 @@ these variables to build a rule in the form: ``if the page of the first and
 last notes are equal, write a singular form and just one value but, if they
 are different, write a plural form and a range of both values''.
 \cs{pnhdchapfirst}, \cs{pnhdchaplast}, \cs{pnhdsectfirst}, and
-\cs{pnhdsectfirst} provide the same for \cs{thechapter} and \cs{thesection}.
+\cs{pnhdsectlast} provide the same for \cs{thechapter} and \cs{thesection}.
 \cs{pnhdnamefirst} and \cs{pnhdnamelast} contain the name of the notes
 section, the one given with the \opt{name} option of \cs{postnotesection} (and
 are empty in case no \opt{name} was provided).

--- a/postnotes-doc.tex
+++ b/postnotes-doc.tex
@@ -1112,4 +1112,10 @@ upon release so, most likely, \texttt{texdoc postnotes/changelog} should
 provide easy local access to it.  An archive of historical versions of the
 package is also kept at \url{https://github.com/gusbrs/postnotes/releases}.
 
+
+\section{Implementation}
+
+For those who would like to see the implementation of this package,
+just type \texttt{texdoc postnotes-code} in the terminal to get the code documentation.
+
 \end{document}


### PR DESCRIPTION
Since `\postnotes` isn't actually a command provided by this package, I changed the `\cs{postnotes}` into `postnotes`.